### PR TITLE
Support custom sockets

### DIFF
--- a/examples/esp32_wifi_coap_client.py
+++ b/examples/esp32_wifi_coap_client.py
@@ -1,0 +1,80 @@
+import network
+import machine
+import microcoapy.microcoapy as microcoapy
+
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+
+_MY_SSID = 'myssid'
+_MY_PASS = 'mypass'
+_SERVER_IP = '192.168.1.2'
+_SERVER_PORT = 5683  # default CoAP port
+_COAP_URL = 'to/a/path'
+
+
+def connectToWiFi():
+    nets = wlan.scan()
+    for net in nets:
+        ssid = net[0].decode("utf-8")
+        if ssid == _MY_SSID:
+            print('Network found!')
+            wlan.connect(ssid, _MY_PASS)
+            while not wlan.isconnected():
+                machine.idle()  # save power while waiting
+            print('WLAN connection succeeded!')
+            break
+
+    return wlan.isconnected()
+
+
+def sendPostRequest(client):
+    # About to post message...
+    bytesTransferred = client.post(_SERVER_IP, _SERVER_PORT, _COAP_URL, "test",
+                                   None, microcoapy.COAP_CONTENT_TYPE.COAP_TEXT_PLAIN)
+    print("Sent bytes: ", bytesTransferred)
+
+    # wait for respose to our request for 2 seconds
+    client.poll(2000)
+
+
+def sendPutRequest(client):
+    # About to post message...
+    bytesTransferred = client.put(_SERVER_IP, _SERVER_PORT, "led/turnOn", "test",
+                                   "authorization=8c6ebe8a-82d4-421d-89d3-28a7c48c7ec0",
+                                   microcoapy.COAP_CONTENT_TYPE.COAP_TEXT_PLAIN)
+    print("[PUT] Sent bytes: ", bytesTransferred)
+
+    # wait for respose to our request for 2 seconds
+    client.poll(2000)
+
+
+def sendGetRequest(client):
+    # About to post message...
+    bytesTransferred = client.get(_SERVER_IP, _SERVER_PORT, "current/measure")
+    print("[GET] Sent bytes: ", bytesTransferred)
+
+    # wait for respose to our request for 2 seconds
+    client.poll(2000)
+
+
+def receivedMessageCallback(packet, sender):
+        print('Message received:', packet, ', from: ', sender)
+        if(hasattr(packet, 'p')):
+            print('Mesage payload: ', packet.p)
+
+
+connectToWiFi()
+
+client = microcoapy.Coap()
+# setup callback for incoming respose to a request
+client.resposeCallback = receivedMessageCallback
+
+# Starting CoAP...
+client.start()
+
+sendPostRequest(client)
+sendPutRequest(client)
+sendGetRequest(client)
+
+# stop CoAP
+client.stop()

--- a/examples/esp32_wifi_coap_client_custom_socket.py
+++ b/examples/esp32_wifi_coap_client_custom_socket.py
@@ -41,7 +41,7 @@ def sendPostRequest(client):
 def sendPutRequest(client):
     # About to post message...
     bytesTransferred = client.put(_SERVER_IP, _SERVER_PORT, "led/turnOn", "test",
-                                   "authorization=8c6ebe8a-82d4-421d-89d3-28a7c48c7ec0",
+                                   "authorization=1234567",
                                    microcoapy.COAP_CONTENT_TYPE.COAP_TEXT_PLAIN)
     print("[PUT] Sent bytes: ", bytesTransferred)
 

--- a/examples/esp32_wifi_coap_client_custom_socket.py
+++ b/examples/esp32_wifi_coap_client_custom_socket.py
@@ -64,6 +64,24 @@ def receivedMessageCallback(packet, sender):
             print('Mesage payload: ', packet.p)
 
 
+################################################################################
+## Custom socket implementation
+class CustomSocket:
+    def __init__(self):
+        print("CustomSocket: init")
+
+    def sendto(self, bytes, address):
+        print("CustomSocket: Sending bytes to: " + str(address))
+        return len(bytes)
+
+    def recvfrom(self, bufsize):
+        print("CustomSocket: receiving max bytes: " + bufsize)
+        return b"test data"
+
+    def setblocking(self, flag):
+        print(".", end="")
+################################################################################
+
 connectToWiFi()
 
 client = microcoapy.Coap()
@@ -71,8 +89,7 @@ client = microcoapy.Coap()
 client.resposeCallback = receivedMessageCallback
 
 # Initialize custom socket
-customSocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-customSocket.bind(('', 5683))
+customSocket = CustomSocket()
 
 # Use custom socket to all operations of CoAP
 client.setCustomSocket(customSocket)
@@ -80,6 +97,3 @@ client.setCustomSocket(customSocket)
 sendPostRequest(client)
 sendPutRequest(client)
 sendGetRequest(client)
-
-# close socket
-customSocket.close()

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -473,5 +473,5 @@ class Coap:
 
     def poll(self, timeoutMs=-1):
         start_time = time.ticks_ms()
-        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time)):
+        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time)) < timeoutMs:
             time.sleep_ms(10)

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -171,7 +171,7 @@ class Coap:
     # The custom socket must support functions:
     # * socket.sendto(bytes, address)
     # * socket.recvfrom(bufsize)
-    # * socket.setblocking(flag) 
+    # * socket.setblocking(flag)
     def setCustomSocket(self, custom_socket):
         self.stop()
         self.sock = custom_socket
@@ -453,8 +453,6 @@ class Coap:
 
             packet = CoapPacket()
 
-            print("About to process: ", buffer)
-
             self.parsePacketHeaderInfo(buffer, packet)
 
             if not self.parsePacketToken(buffer, packet):
@@ -462,8 +460,6 @@ class Coap:
 
             if not self.parsePacketOptionsAndPayload(buffer, packet):
                 return False
-
-            print("Received: ", packet)
 
             if packet.type == COAP_TYPE.COAP_ACK or\
                packet.code == COAP_RESPONSE_CODE.COAP_NOT_FOUND:

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -168,6 +168,10 @@ class Coap:
     #
     # Note: This overrides the automatic socket that has been created
     # by the 'start' function.
+    # The custom socket must support functions:
+    # * socket.sendto(bytes, address)
+    # * socket.recvfrom(bufsize)
+    # * socket.setblocking(flag) 
     def setCustomSocket(self, custom_socket):
         self.stop()
         self.sock = custom_socket

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -471,7 +471,7 @@ class Coap:
 
         return False
 
-    def poll(self, timeoutMs=-1):
+    def poll(self, timeoutMs=-1, pollPeriodMs=500):
         start_time = time.ticks_ms()
-        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time)) < timeoutMs:
-            time.sleep_ms(10)
+        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time) < timeoutMs):
+            time.sleep_ms(pollPeriodMs)

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -150,14 +150,27 @@ class Coap:
         self.resposeCallback = None
         self.port = 0
 
+    # Create and initialize a new UDP socket to listen to.
+    # port: the local port to be used.
     def start(self, port=_COAP_DEFAULT_PORT):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.bind(('', port))
 
+    # Stop and destroy the socket that has been created by
+    # a previous call of 'start' function
     def stop(self):
         if self.sock is not None:
             self.sock.close()
             self.sock = None
+
+    # Set a custom instance of a UDP socket
+    # Is used instead of calling start/stop functions.
+    #
+    # Note: This overrides the automatic socket that has been created
+    # by the 'start' function.
+    def setCustomSocket(self, custom_socket):
+        self.stop()
+        self.sock = custom_socket
 
     def addIncomingRequestCallback(self, requestUrl, callback):
         self.callbacks[requestUrl] = callback
@@ -336,6 +349,8 @@ class Coap:
         if endOfOptionIndex > len(buffer):
             return errorMessage
 
+        #print("Option number:", delta + runningDelta, ", buflen: from: ", i+1, " -> ", length)
+
         option.number = delta + runningDelta
         option.buffer = buffer[i+1:i+1+length]
         packet.options.append(option)
@@ -371,7 +386,6 @@ class Coap:
                               None, COAP_RESPONSE_CODE.COAP_NOT_FOUND,
                               COAP_CONTENT_TYPE.COAP_NONE, None)
         else:
-            print("redirecting packet to handlers...")
             urlCallback(requestPacket, sourceIp, sourcePort)
 
     def readBytesFromSocket(self, numOfBytes):
@@ -435,6 +449,8 @@ class Coap:
 
             packet = CoapPacket()
 
+            print("About to process: ", buffer)
+
             self.parsePacketHeaderInfo(buffer, packet)
 
             if not self.parsePacketToken(buffer, packet):
@@ -442,6 +458,8 @@ class Coap:
 
             if not self.parsePacketOptionsAndPayload(buffer, packet):
                 return False
+
+            print("Received: ", packet)
 
             if packet.type == COAP_TYPE.COAP_ACK or\
                packet.code == COAP_RESPONSE_CODE.COAP_NOT_FOUND:
@@ -453,7 +471,7 @@ class Coap:
 
         return False
 
-    def poll(self, timeoutMs=-1, pollPeriodMs=500):
+    def poll(self, timeoutMs=-1):
         start_time = time.ticks_ms()
-        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time) < timeoutMs):
-            time.sleep_ms(pollPeriodMs)
+        while not self.loop(False) and (time.ticks_diff(time.ticks_ms(), start_time)):
+            time.sleep_ms(10)


### PR DESCRIPTION
This PR adds support for sockets that have been created outside of the microCoAPy library. 

Thus, instead of calling __start__ and __stop__ functions that automatically handle the sockets, __setCustomSocket__ can be called to set the desired socket explicitly. 

The custom socket must have the following functions implemented:

 * socket.sendto(bytes, address) https://docs.micropython.org/en/latest/library/usocket.html#usocket.socket.sendto
 * socket.recvfrom(bufsize) https://docs.micropython.org/en/latest/library/usocket.html#usocket.socket.recvfrom
 * socket.setblocking(flag) https://docs.micropython.org/en/latest/library/usocket.html#usocket.socket.setblocking

This change, when merged, will handle the request #1