### PR TITLE
Allow using this library on system without usocket module

### DIFF
--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -1,5 +1,5 @@
 try:
-    import usocket
+    import usocket as socket
 except ImportError:
     pass
 import uos

--- a/microcoapy/microcoapy.py
+++ b/microcoapy/microcoapy.py
@@ -1,4 +1,7 @@
-import usocket as socket
+try:
+    import usocket
+except ImportError:
+    pass
 import uos
 import utime as time
 from . import coap_macros as macros


### PR DESCRIPTION
Hello,

This PR is to enable using this library on system without `usocket` module like MicroPython for RP2 without network support.
I'm preparing example of using microCoAPy on RP2 with ENC28J60 Ethernet driver and custom socket: https://github.com/przemobe/micropy-ENC28J60/blob/main/examples/MicrocoapyClient.py

This change, when merged, will help handle the issue: https://github.com/przemobe/micropy-ENC28J60/issues/5.

Thank you.
